### PR TITLE
Add submodule update/init to just gen-project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# local dev miscellany
+.bash_history_local
+.envrc
+
 # generated part of documentation
 /docs/elements/*.md
 /docs/schema/*.yaml

--- a/justfile
+++ b/justfile
@@ -76,7 +76,12 @@ clean: _clean_project
 
 # (Re-)Generate project and documentation locally
 [group('model development')]
-site: gen-project gen-doc
+site: gen-project gen-doc gensqla
+
+# SQL Alchemy model
+[group('model development')]
+gensqla: _gen_sqla
+
 
 # Deploy documentation site to Github Pages
 [group('deployment')]
@@ -113,7 +118,7 @@ gen-python:
 
 # Generate project files including Python data model
 [group('model development')]
-gen-project:
+gen-project: _merge_common
   uv run gen-project {{config_yaml}} -d {{dest}} {{source_schema_path}}
   mv {{dest}}/*.py {{pymodel}}
   uv run gen-pydantic {{gen_pydantic_args}} {{source_schema_path}} > {{pymodel}}/{{schema_name}}_pydantic.py

--- a/project.justfile
+++ b/project.justfile
@@ -1,1 +1,13 @@
 ## Add your own just recipes here. This is imported by the main justfile.
+
+# Overriding recipes from the root justfile by adding a recipe with the same
+# name in this file is not possible until a known issue in just is fixed,
+# https://github.com/casey/just/issues/2540
+[group('model development')]
+_merge_common:
+    git submodule update --remote --merge --init
+
+[group('model development')]
+_gen_sqla:
+    mkdir -p {{dest}}/sqlalchemy && \
+    uv run gen-sqla {{source_schema_path}} --declarative > {{dest}}/sqlalchemy/{{schema_name}}.py

--- a/project.justfile
+++ b/project.justfile
@@ -5,7 +5,7 @@
 # https://github.com/casey/just/issues/2540
 [group('model development')]
 _merge_common:
-    git submodule update --remote --merge --init
+    git submodule update --init --recursive
 
 [group('model development')]
 _gen_sqla:


### PR DESCRIPTION
Small change to make sure the submodule is properly initialized and merged in before the project is built. I'm hopeful this won't mess up the automated doc generation...